### PR TITLE
Update About page design to match Figma design

### DIFF
--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -1,9 +1,24 @@
 
 const About = () => {
     return (
-        <div className="w-full h-screen flex justify-center items-top pt-24 border-4 border-white">
-            <div className="text-6xl font-bold text-white font-game1">
+        <div className="w-full h-screen flex flex-col justify-evenly content-between uppercase">
+            <div className="text-2xl font-normal text-white font-game2 flex items-center justify-center">
                 About Us
+            </div>
+            <div className="flex flex-col max-w-[61%] pl-32 space-y-6">
+                <div className="text-2xl font-normal text-white font-game2">What's GDSC?</div>
+                <div className="text-2xl font-normal text-white font-game1">
+                    Google collaborates with university students who are passionate about growing developer communities. GDSC is an Organisation for university students who want to bring about a change through technology. We are focused upon building technical and non-technical skills, which would help students to build a better community.
+                </div>
+            </div>
+            <div className="flex flex-col max-w-[61%] pl-32 space-y-6">
+                <div className="text-2xl font-normal text-white font-game2">What GDSC GHRIETN does?</div>
+                <ul className="text-2xl font-normal text-white font-game1 list-disc list-inside pl-4">
+                    <li className="leading-none">Projects</li>
+                    <li className="leading-none">Seminars</li>
+                    <li className="leading-none">Hackathons</li>
+                    <li className="leading-none">Study Jams</li>
+                </ul>
             </div>
         </div>
     )

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -1,19 +1,19 @@
 
 const About = () => {
     return (
-        <div className="w-full h-screen flex flex-col justify-evenly content-between uppercase">
-            <div className="text-2xl font-normal text-white font-game2 flex items-center justify-center">
+        <div className="w-full min-h-screen md:h-screen flex flex-col justify-evenly content-between uppercase">
+            <div className="text-xl lg:text-2xl font-normal text-white font-game2 flex items-center justify-center">
                 About Us
             </div>
-            <div className="flex flex-col max-w-[61%] pl-20 space-y-6">
-                <div className="text-2xl font-normal text-white font-game2">What's GDSC?</div>
-                <div className="text-2xl font-normal text-white font-game1 leading-none">
+            <div className="flex flex-col lg:max-w-[75%] xl:max-w-[61%] px-7 md:px-10 lg:pl-20 space-y-6">
+                <div className="text-xl lg:text-2xl font-normal text-white font-game2">What's GDSC?</div>
+                <div className="text-xl lg:text-[1.5rem] font-normal text-white font-game1 leading-none">
                     Google collaborates with university students who are passionate about growing developer communities. GDSC is an Organisation for university students who want to bring about a change through technology. We are focused upon building technical and non-technical skills, which would help students to build a better community.
                 </div>
             </div>
-            <div className="flex flex-col max-w-[61%] pl-20 space-y-6">
-                <div className="text-2xl font-normal text-white font-game2">What GDSC GHRIETN does?</div>
-                <ul className="leading-none text-2xl font-normal text-white font-game1 list-disc list-inside pl-4">
+            <div className="flex flex-col lg:max-w-[75%] xl:max-w-[61%] px-7 md:px-10 lg:pl-20 space-y-6">
+                <div className="text-xl lg:text-2xl font-normal text-white font-game2">What GDSC GHRIETN does?</div>
+                <ul className="leading-none text-xl lg:text-[1.5rem] font-normal text-white font-game1 list-disc list-inside pl-4">
                     <li>Projects</li>
                     <li>Seminars</li>
                     <li>Hackathons</li>

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -5,19 +5,19 @@ const About = () => {
             <div className="text-2xl font-normal text-white font-game2 flex items-center justify-center">
                 About Us
             </div>
-            <div className="flex flex-col max-w-[61%] pl-32 space-y-6">
+            <div className="flex flex-col max-w-[61%] pl-20 space-y-6">
                 <div className="text-2xl font-normal text-white font-game2">What's GDSC?</div>
-                <div className="text-2xl font-normal text-white font-game1">
+                <div className="text-2xl font-normal text-white font-game1 leading-none">
                     Google collaborates with university students who are passionate about growing developer communities. GDSC is an Organisation for university students who want to bring about a change through technology. We are focused upon building technical and non-technical skills, which would help students to build a better community.
                 </div>
             </div>
-            <div className="flex flex-col max-w-[61%] pl-32 space-y-6">
+            <div className="flex flex-col max-w-[61%] pl-20 space-y-6">
                 <div className="text-2xl font-normal text-white font-game2">What GDSC GHRIETN does?</div>
-                <ul className="text-2xl font-normal text-white font-game1 list-disc list-inside pl-4">
-                    <li className="leading-none">Projects</li>
-                    <li className="leading-none">Seminars</li>
-                    <li className="leading-none">Hackathons</li>
-                    <li className="leading-none">Study Jams</li>
+                <ul className="leading-none text-2xl font-normal text-white font-game1 list-disc list-inside pl-4">
+                    <li>Projects</li>
+                    <li>Seminars</li>
+                    <li>Hackathons</li>
+                    <li>Study Jams</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
# Closes issue #46 

## Description
This pull request aims to update the design of the About page to match the Figma design shared by @sahilyeole. The changes include restructuring the layout, adjusting font sizes, and organizing content to align with the provided design.

## Changes Made
- Reorganized layout using flexbox for better alignment and spacing
- Adjusted font sizes and styles to match the provided design
- Split content into sections for better readability
- Incorporated provided content for all the sections

## Screenshots
<img width="1440" alt="Screenshot 2024-02-21 at 1 16 19 AM" src="https://github.com/gdsc-ghrietn/gdsc-website/assets/108215785/b2eb595b-5b70-4033-8847-d31b5ca42637">



## Additional Notes
- The Figma design specifies a font size of 48px; however, I have adjusted the font sizes based on my discretion. This decision was made because the height and width of the About component in the actual application do not match the dimensions in Figma. As a result, using the specified 48px font size would make the text appear too large in this context.
